### PR TITLE
chatspace データベース設計　README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,50 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|body  |text|null:fals|
+|image |string|null:fals|
+|user_id|integer|null:fals|
+|group_id|integer|null:fals|
+
+Association
+belongs_to: group
+belongs_to: user
+
+
+userテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null:fals|
+|email|string|null:fals, unique:true|
+|password|string|null:fals, unique:true|
+
+Association
+has_many: messages
+has_many: groups
+has_many: groups_users
+
+
+groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|groups_name|integer|null:false, unique:true|
+
+Association
+has_many: messages
+has_many: users
+has_many: groups_users
+
+
+groups_usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null:false|
+|groups_id|integer|null:false|
+
+Association
+belongs_to: group
+belongs_to: user

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Things you may want to cover:
 messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|body  |text|null:fals|
-|image |string|null:fals|
-|user_id|integer|null:fals|
-|group_id|integer|null:fals|
+|body  |text|       |
+|image |string|     |
+|user_id|integer|null:false, foreign_key: true|
+|group_id|integer|null:false, foreign_key: true|
 
 Association
 belongs_to: group
@@ -39,32 +39,32 @@ belongs_to: user
 userテーブル
 |Column|Type|Options|
 |------|----|-------|
-|name|string|null:fals|
-|email|string|null:fals, unique:true|
-|password|string|null:fals, unique:true|
+|name|string|null:false|
+|email|string|null:false, unique:true|
+|password|string|null:false, unique:true|
 
 Association
 has_many: messages
-has_many: groups
+has_many: groups, through: groups_users
 has_many: groups_users
 
 
 groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|groups_name|integer|null:false, unique:true|
+|name|integer|null:false, unique:true|
 
 Association
 has_many: messages
-has_many: users
+has_many: users, through: groups_users
 has_many: groups_users
 
 
 groups_usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null:false|
-|groups_id|integer|null:false|
+|user_id|integer|null:false, foreign_key: true|
+|group_id|integer|null:false, foreign_key: true|
 
 Association
 belongs_to: group

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ has_many: groups_users
 groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|name|integer|null:false, unique:true|
+|name|string|null:false, unique:true|
 
 Association
 has_many: messages


### PR DESCRIPTION
#what
chat-spaceのデータベースの設計を行う。　各テーブル　users groups messages 中間テーブル　groups_usersを作成する。各テーブル間のリレーションも記述する。

#why
chat-spaceの根幹であるデータベースを作成